### PR TITLE
Version 1.21.0, 2026-08-23

### DIFF
--- a/Dockerfile_Ubuntu-26.04
+++ b/Dockerfile_Ubuntu-26.04
@@ -1,6 +1,6 @@
-# Ubuntu 22.04 for QMS V_1.20.3
+# Ubuntu 26.04 for QMS V_1.21.0
 
-FROM	ubuntu:22.04
+FROM	ubuntu:26.04
 
 LABEL	description="QMapShack.AppImage development build"
 
@@ -11,11 +11,11 @@ RUN	apt-get -y update \
 	
 # Install needed packages
 RUN	apt-get -y install build-essential wget subversion libxcb-cursor0 libxcb-cursor-dev \
-	cmake git libgl-dev libsqlite3-dev sqlite3 libtiff-dev libcurl4-nss-dev \
+	cmake git libgl-dev libsqlite3-dev sqlite3 libtiff-dev libcurl4-openssl-dev \
 	libxkbcommon-dev libvulkan-dev libcups2-dev libghc-bzlib-dev fuse file \
 	libwayland-cursor0 libwayland-egl1 libgtk-3-0 libxkbcommon-x11-0 libxcb-icccm4 \
 	libxcb-keysyms1 libxcb-shape0 libpq5 unixodbc-dev libmysqlclient-dev libglib2.0-0 \
-	libxcomposite1 libxdamage1 libxrandr2 libxrender1 libxtst6 libxi6 libasound2 \
+	libxcomposite1 libxdamage1 libxrandr2 libxrender1 libxtst6 libxi6 libasound2t64 \
 	libgbm1 libxkbfile1 libegl1
 
 # Copy the pre-build Qt environment from host
@@ -26,29 +26,29 @@ RUN	cd /AppDir \
 	&& rm Qt-6.8.3_Ubuntu-22.04.tar.gz \
 	&& cd /
 
-# Install PROJ 9.4.1
+# Install PROJ 9.8.1
 # See https://proj.org/
-RUN	wget https://download.osgeo.org/proj/proj-9.4.1.tar.gz \
-	&& tar xzvf proj-9.4.1.tar.gz \
-	&& cd proj-9.4.1 \
+RUN	wget https://download.osgeo.org/proj/proj-9.8.1.tar.gz \
+	&& tar xzvf proj-9.8.1.tar.gz \
+	&& cd proj-9.8.1 \
 	&& mkdir build \
 	&& cd build \
 	&& cmake .. -DCMAKE_INSTALL_PREFIX=/usr \
 	&& cmake --build . -j$(nproc) --target install \
 	&& cd / \
-	&& rm -rf proj-9.4.1.tar.gz proj-9.4.1
+	&& rm -rf proj-9.8.1.tar.gz proj-9.8.1
 
-# Install GDAL 3.9.0
+# Install GDAL 3.13.3
 # See https://gdal.org/
-RUN wget https://github.com/OSGeo/gdal/releases/download/v3.9.0/gdal-3.9.0.tar.gz \
-	&& tar xvzf gdal-3.9.0.tar.gz \
-	&& cd gdal-3.9.0 \
+RUN wget https://github.com/OSGeo/gdal/releases/download/v3.13.3/gdal-3.13.3.tar.gz \
+	&& tar xvzf gdal-3.13.3.tar.gz \
+	&& cd gdal-3.13.3 \
 	&& mkdir build \
 	&& cd build \
 	&& cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release \
 	&& cmake --build . -j$(nproc) --target install \
 	&& cd / \
-	&& rm -rf gdal-3.9.0.tar.gz gdal-3.9.0
+	&& rm -rf gdal-3.13.3.tar.gz gdal-3.13.3
 
 # Install QUAZIP 1.5
 # See https://stachenov.github.io/quazip/

--- a/README.md
+++ b/README.md
@@ -19,23 +19,20 @@ Then, may be you could use a ready to go one-click QMapshack.AppImage executable
 
 ## Build based on
 
-* Ubuntu 22.04
+* Ubuntu 26.04
 * GNOME / X11
 * GLIBC 2.35
 * cmake 3.22.1
 * Qt 6.8.3
-* PROJ 9.4.1
-* GDAL 3.9.0
+* PROJ 9.8.1
+* GDAL 3.13.3
 * QUAZIP 1.5
 * Routino 3.4.3
-* QMapShack V_1.20.3, commit [2c00386](https://github.com/Maproom/qmapshack/commit/2c0038663131460c7d4bbc0f3c35a16a17d5628b), [QMS-1105] Fix: Context menu shortcuts not shown (macOS)
+* QMapShack V_1.21.0, commit [2ee7589](https://github.com/Maproom/qmapshack/commit/2ee75893bbf7ae13c4671233566507e3031cab58), Update version to 1.21.0
 
 ## Tested Linux distributions
 
-* Ubuntu 22.04, 24.04, 26.04
-* Fedora Workstation 43, 44 / Gnome / Wayland
-* openSUSE 15.6, 16.0 / KDE
-* Linux Mint 22.3 "Zena" Cinnamon / Xfce / MATE
+* Ubuntu 26.04
 
 **Remark for openSUSE 16.0 / KDE**
 
@@ -43,7 +40,7 @@ To run QMapShack.AppImage in a newly installed system environment, two libraries
 
 `sudo zypper install libatomic1 libgthread-2_0-0`
 
-**Remark for Ubuntu 22.04 and Linux Mint 22.3 "Zena" Cinnamon / Xfce / MATE**
+**Remark for Ubuntu 22.04+ and Linux Mint 22.3 "Zena" Cinnamon / Xfce / MATE**
 
 To run QMapShack.AppImage in a newly installed system environment, one library must be installed:
 
@@ -51,7 +48,7 @@ To run QMapShack.AppImage in a newly installed system environment, one library m
 
 ## Download
 
-[Download pre-build QMapShack-x86_64.AppImage from here (648 MB)](https://github.com/kkarsten62/QMapShack.AppImage/releases/download/V_1.20.3/QMapShack-x86_64.AppImage)
+[Download pre-build QMapShack-x86_64.AppImage from here (657 MB)](https://github.com/kkarsten62/QMapShack.AppImage/releases/download/V_1.21.0/QMapShack-x86_64.AppImage)
 
 After download change user rights for execution:
 
@@ -75,7 +72,7 @@ or to see the debug messages:
 * A Linux distribution - able to run Docker software
 * Docker installation
 * At least ~5 GB free disk space
-* 1-2 hour for the initial Docker image build
+* 1-2 hour for the initial Docker image build (15mn on a 2024 laptop)
 * 5 minutes for each development update
 * Some Linux skills to handle a terminal
 
@@ -125,7 +122,7 @@ Build the image:
 
 For example:
 
-`sudo docker build -t qms-appimage:0.0.0 --no-cache --file Dockerfile_Ubuntu-22.04 .`
+`sudo docker build -t qms-appimage:0.0.0 --no-cache --file Dockerfile_Ubuntu-26.04 .`
 
 **Note:**
 * Be patient and take a coffee, build process will take some time - about 1-2 hours

--- a/build_AppImage.sh
+++ b/build_AppImage.sh
@@ -5,7 +5,9 @@ set -e
 # Make and install QMapShack
 # Use "git pull <commit|tag|branch>" when compiling for a specific commit
 cd /qmapshack
+git checkout dev
 git pull
+git checkout tags/V_1.20.3 
 cd /build
 make qmapshack -j$(nproc)
 make install DESTDIR=/AppDir


### PR DESCRIPTION
Bugs fixed and enhancements:
[32] Provide a release build based on QMS V_1.21.0
- Latest QMS Commit, 2026-08-23: "Update version to 1.21.0"
- One pre-build based on Ubuntu 26.04 for some Linux distributions

Changes to be committed:
renamed:    Dockerfile_Ubuntu-22.04 -> Dockerfile_Ubuntu-26.04
modified:   README.md
modified:   build_AppImage.sh